### PR TITLE
Allow protelis to use an variabile in hood calls

### DIFF
--- a/protelis.parser.ui/META-INF/MANIFEST.MF
+++ b/protelis.parser.ui/META-INF/MANIFEST.MF
@@ -22,5 +22,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.protelis.parser.ui.quickfix,
  org.protelis.parser.ui.contentassist,
  org.protelis.parser.ui.contentassist.antlr,
- org.protelis.parser.ui.internal
+ org.protelis.parser.ui.internal,
+ org.protelis.parser.ui.contentassist.antlr.internal
 Bundle-Activator: org.protelis.parser.ui.internal.ProtelisActivator

--- a/protelis.parser/src/org/protelis/parser/Protelis.xtext
+++ b/protelis.parser/src/org/protelis/parser/Protelis.xtext
@@ -91,7 +91,7 @@ Hood:
 
 GenericHood:
 		(name = 'hood' | name = 'hoodPlusSelf') '('
-			(reference = [ecore::EObject|CallRule] | op = Lambda ) ','
+			(reference = VarUse | op = Lambda ) ','
 			default = Expression ','
 			arg = Expression
 		')'

--- a/protelis.parser/src/org/protelis/parser/scoping/ProtelisScopeProvider.xtend
+++ b/protelis.parser/src/org/protelis/parser/scoping/ProtelisScopeProvider.xtend
@@ -66,10 +66,6 @@ class ProtelisScopeProvider extends AbstractDeclarativeScopeProvider {
 		Scopes.scopeFor(Collections.emptyList)
 	}
 	
-	def IScope scope_GenericHood_reference(Module model, EReference ref) {
-		scope_Call_reference(model, ref)
-	}
-	
 	def IScope scope_Call_reference(Module model, EReference ref) {
 		val List<EObject> internal = new ArrayList(model.definitions)
 		val List<IEObjectDescription> externalProtelis = new ArrayList


### PR DESCRIPTION
currently,
```xtend
def a(b) {
    hood(b, 1, nbr(1))
}
```
throws an error (cannot resolve reference to `b`) since b is not a function, even though it could be bound to one. This change removes this limitation, but requires an intervention interpreter-side. As such, this will trigger the release of a new major revision for the parser, and a new mid revision (dependency update) for the interpreter.