### PR TITLE
chore(deps): migrate web demo to Jetty 12 EE10 artifacts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@ xtext = "2.42.0"
 
 [libraries]
 ace = "org.webjars:ace:1.23.4"
-jetty-annotations = "org.eclipse.jetty:jetty-annotations:11.0.26"
+jetty-annotations = "org.eclipse.jetty.ee10:jetty-ee10-annotations:12.1.8"
+jetty-webapp = "org.eclipse.jetty.ee10:jetty-ee10-webapp:12.1.8"
 jquery = "org.webjars:jquery:4.0.0"
 requirejs = "org.webjars:requirejs:2.3.7"
 slf4j-simple = "org.slf4j:slf4j-simple:2.0.17"

--- a/protelis.parser.web/build.gradle.kts
+++ b/protelis.parser.web/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
 	api(project(":protelis.parser.ide"))
 	api(libs.bundles.xtext.web)
 	providedCompile(libs.jetty.annotations)
+	providedCompile(libs.jetty.webapp)
 	providedCompile(libs.slf4j.simple)
 }
 

--- a/protelis.parser.web/src/main/java/org/protelis/parser/web/ServerLauncher.xtend
+++ b/protelis.parser.web/src/main/java/org/protelis/parser/web/ServerLauncher.xtend
@@ -4,13 +4,13 @@
 package org.protelis.parser.web
 
 import java.net.InetSocketAddress
-import org.eclipse.jetty.annotations.AnnotationConfiguration
+import org.eclipse.jetty.ee10.annotations.AnnotationConfiguration
+import org.eclipse.jetty.ee10.webapp.MetaInfConfiguration
+import org.eclipse.jetty.ee10.webapp.WebAppConfiguration
+import org.eclipse.jetty.ee10.webapp.WebAppContext
+import org.eclipse.jetty.ee10.webapp.WebInfConfiguration
+import org.eclipse.jetty.ee10.webapp.WebXmlConfiguration
 import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.webapp.MetaInfConfiguration
-import org.eclipse.jetty.webapp.WebAppConfiguration
-import org.eclipse.jetty.webapp.WebAppContext
-import org.eclipse.jetty.webapp.WebInfConfiguration
-import org.eclipse.jetty.webapp.WebXmlConfiguration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -24,10 +24,8 @@ class ServerLauncher {
 	
 	def static void main(String[] args) {
 		val server = new Server(new InetSocketAddress('localhost', 8080))
-		server.handler = new WebAppContext => [
-			resourceBase = 'src/main/webapp'
+		server.handler = new WebAppContext('src/main/webapp', '/') => [
 			welcomeFiles = #["index.html"]
-			contextPath = "/"
 			configurations = #[
 				new AnnotationConfiguration,
 				new WebXmlConfiguration,


### PR DESCRIPTION
## Summary
- replace `org.eclipse.jetty:jetty-annotations` with `org.eclipse.jetty.ee10:jetty-ee10-annotations:12.1.8`
- add `org.eclipse.jetty.ee10:jetty-ee10-webapp:12.1.8` because Jetty 12 EE10 now provides the `WebAppContext` and related webapp classes from that module
- update the web demo server launcher imports and `WebAppContext` setup for Jetty 12 EE10

## Why
Jetty 12 no longer uses the old Jetty 11 coordinates for this setup. The change is not just a version bump of `org.eclipse.jetty:jetty-annotations`: it migrates the web module to the Jetty 12 EE10 artifacts and requires the webapp module alongside annotations.

In practice, `jetty-ee10-webapp` is now part of the dependency upgrade rationale, not an unrelated addition: the launcher uses `WebAppContext`, `WebXmlConfiguration`, `WebInfConfiguration`, `MetaInfConfiguration`, and `WebAppConfiguration`, which come from the EE10 webapp artifact.

This also implies the Jakarta EE 10 / Servlet 6 API line for the demo web application, which is relevant context for reviewers and downstream users checking compatibility.

## Notes
- behavior is intended to stay the same for the demo server
- the main functional change is dependency/package migration from Jetty 11 namespaces to Jetty 12 EE10 namespaces